### PR TITLE
Support only-option to enable specific rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ ArStemmer.stem("الدونات")
 "دونات"
 ```
 
-When you want to turn off the specific rules for your own purpose, you can pass the name to `disable` option.
+When you want to turn on/off the specific rules for your own purpose, you can pass the name to `only/except` option.
 
 ```
-ArStemmer.stem(word, disable: [:yeh_noon, :waw_noon])
+ArStemmer.stem(word, only: [:alef_lam, :waw_alef_lam])
+ArStemmer.stem(word, except: [:yeh_noon, :waw_noon])
 ```
+
+You can find the rule names in [the source code](https://github.com/tomoya55/ar-stemmer/blob/master/lib/ar_stemmer.rb#L18-L39).
 
 ## License
 

--- a/ar-stemmer.gemspec
+++ b/ar-stemmer.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "ar-stemmer"
-  spec.version       = "0.2.0"
+  spec.version       = "0.3.0"
   spec.authors       = ["Tomoya Hirano"]
   spec.email         = ["hiranotomoya@gmail.com"]
 

--- a/lib/ar_stemmer.rb
+++ b/lib/ar_stemmer.rb
@@ -42,11 +42,18 @@ class ArStemmer
     new(word, options).stem
   end
 
-  attr_reader :word, :disabled
+  attr_reader :word, :excepts, :onlys
 
   def initialize(word, options = {})
     @word = word.dup
-    @disabled = options[:disable] || []
+
+    @onlys = []
+    @excepts = []
+    if options[:only]
+      @onlys = options[:only]
+    elsif options[:except]
+      @excepts = options[:except]
+    end
   end
 
   def stem
@@ -58,7 +65,10 @@ class ArStemmer
   private
 
     def rules(rule_set)
-      rule_set.reject {|k, v| disabled.include?(k) }.values
+      rule_set
+        .reject {|k, v| excepts.any? ? excepts.include?(k) : false }
+        .select {|k, v| onlys.any? ? onlys.include?(k) : true }
+        .values
     end
 
     def stem_prefix

--- a/test/ar_stemmer_test.rb
+++ b/test/ar_stemmer_test.rb
@@ -85,11 +85,19 @@ class ArStemmerTest < Minitest::Test
     assert_stem "English", "English"
   end
 
-  def test_disable_option
+  def test_only_option
+    al_word = "الحسن"
+    wal_word = "والحسن"
+    word = "حسن"
+    assert_equal word, ArStemmer.stem(al_word, only: [:alef_lam, :waw_alef_lam])
+    assert_equal word, ArStemmer.stem(wal_word, only: [:alef_lam, :waw_alef_lam])
+  end
+
+  def test_except_option
     yn_word = "ساهدين"
     wn_word = "ساهدون"
-    assert_equal yn_word, ArStemmer.stem(yn_word, disable: [:yeh_noon, :waw_noon])
-    assert_equal wn_word, ArStemmer.stem(wn_word, disable: [:yeh_noon, :waw_noon])
+    assert_equal yn_word, ArStemmer.stem(yn_word, except: [:yeh_noon, :waw_noon])
+    assert_equal wn_word, ArStemmer.stem(wn_word, except: [:yeh_noon, :waw_noon])
   end
 
   def assert_stem(word, stem)


### PR DESCRIPTION
This PR includes 2 changes
1. add support of `only` option to specify rules
2. renamed `disable` to `except` to be consistent with `only` option
