### PR TITLE
add BEH to Prefixes

### DIFF
--- a/lib/ar_stemmer.rb
+++ b/lib/ar_stemmer.rb
@@ -3,17 +3,17 @@
 # https://github.com/apache/lucene-solr/blob/master/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicStemmer.java
 class ArStemmer
 
-  ALEF = "\u0627"
-  BEH = "\u0628"
-  TEH_MARBUTA = "\u0629"
-  TEH = "\u062A"
-  FEH = "\u0641"
-  KAF = "\u0643"
-  LAM = "\u0644"
-  NOON = "\u0646"
-  HEH = "\u0647"
-  WAW = "\u0648"
-  YEH = "\u064A"
+  ALEF = "\u0627" # --> أ
+  BEH = "\u0628" # --> ب
+  TEH_MARBUTA = "\u0629" # --> ة
+  TEH = "\u062A" # --> ت
+  FEH = "\u0641" # --> ف
+  KAF = "\u0643" # --> ك
+  LAM = "\u0644" # --> ل
+  NOON = "\u0646" # --> ن
+  HEH = "\u0647" # --> ه
+  WAW = "\u0648" # --> و
+  YEH = "\u064A" # --> ي
 
   PREFIXES = {
     alef_lam:     ALEF + LAM,
@@ -22,7 +22,8 @@ class ArStemmer
     kaf_alef_lam: KAF + ALEF + LAM,
     feh_alef_lam: FEH + ALEF + LAM,
     lam_lam:      LAM + LAM,
-    waw:          WAW
+    waw:          WAW,
+    beh:          BEH
   }
 
   SUFFIXES = {
@@ -84,7 +85,7 @@ class ArStemmer
     end
 
     def starts_with_check_length(word, prefix)
-      if prefix.length == 1 && word.length < 4 # wa- prefix requires at least 3 characters
+      if prefix.length == 1 && word.length < 3 # 'waw' and 'beh' prefix requires at least 3 characters
         false
       elsif word.length < prefix.length + 2
         false

--- a/test/ar_stemmer_test.rb
+++ b/test/ar_stemmer_test.rb
@@ -29,6 +29,10 @@ class ArStemmerTest < Minitest::Test
     assert_stem "وحسن", "حسن"
   end
 
+  def test_beh_prefix
+    assert_stem "برز", "رز"
+  end
+
   def test_ah_suffix
     assert_stem "زوجها", "زوج"
   end
@@ -77,8 +81,11 @@ class ArStemmerTest < Minitest::Test
     assert_stem "ساهدهات", "ساهد"
   end
 
-  def test_shouldnt_stem
+  def test_shouldnt_stem_connectors
     assert_stem "الو", "الو"
+    assert_stem "ول",  "ول"
+    assert_stem "فل",  "فل"
+    assert_stem "بل",  "بل"
   end
 
   def test_non_arabic


### PR DESCRIPTION
#### Changes:
- added `BEH(ب)` to `PREFIXES`
-  updated [this condition](https://github.com/mshka/ar-stemmer/blob/652010d7d786a158d13331c5016163c73d56d29e/lib/ar_stemmer.rb#L88) so it would stem small words like `ورز` and `برز` but not connectors
- updated test file

E.x:

```
رز <-- ورز
رز <-- برز
قرنبيط <-- بقرنبيط
----
ول <-- ول
الى <-- الى
```

@tomoya55 please review
