### PR TITLE
Stemmer is stemming more than the prefixes

### DIFF
--- a/lib/ar_stemmer.rb
+++ b/lib/ar_stemmer.rb
@@ -73,7 +73,7 @@ class ArStemmer
 
     def stem_prefix
       rules(PREFIXES).each do |prefix|
-        @word = word[prefix.length .. -1] if starts_with_check_length(word, prefix)
+        return @word = word[prefix.length .. -1] if starts_with_check_length(word, prefix)
       end
     end
 

--- a/test/ar_stemmer_test.rb
+++ b/test/ar_stemmer_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ArStemmerTest < Minitest::Test
   def test_al_prefix
@@ -27,6 +27,12 @@ class ArStemmerTest < Minitest::Test
 
   def test_wa_prefix
     assert_stem "وحسن", "حسن"
+  end
+
+  def test_stem_prefix_and_stop
+    assert_stem "البيض", "بيض"
+    assert_stem "البسبوسة", "بسبوس"
+    assert_stem "بالبطاطا", "بطاطا"
   end
 
   def test_ah_suffix


### PR DESCRIPTION
after some testing i got an issue:
words that start with same characters as the prefixes would still be stemmed after the first stem due to to the [prefix loop](https://github.com/tomoya55/ar-stemmer/blob/master/lib/ar_stemmer.rb#L76) 😓 

for example if a word originally start with a `beh_alef_lam(bal)` and has a `alef_lam(al)` or any other prefix would be stemmed 2 times

```
الباليه --> يه
البسبوسة --> سبوس
البيض --> يض
```

so stoping the loop after the first stem would fix this, since the gem handle the rare cases where a [2 prefixes exists](https://github.com/tomoya55/ar-stemmer/blob/master/lib/ar_stemmer.rb#L20-L23) at the same time and i don't think there is any other case where a word can have 2 prefixes at once!
##### After:

```
البسبوسة --> بسبوس
البيض --> بيض
```

`الباليه --> يه`

am not sure if the same thing applies to the SUFFIXES 😅 

@tomoya55  please review
